### PR TITLE
Fix kerberos support by logging in user.

### DIFF
--- a/src/main/scala/com/odsklm/salsabeach/HBase.scala
+++ b/src/main/scala/com/odsklm/salsabeach/HBase.scala
@@ -4,10 +4,10 @@ import com.odsklm.salsabeach.types.ColumnDefs._
 import com.typesafe.config.ConfigFactory
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.hadoop.conf.Configuration
-import org.apache.hadoop.hbase.client.{Connection, ConnectionFactory, Table}
+import org.apache.hadoop.hbase.client.{Connection, Table, ConnectionFactory}
 import org.apache.hadoop.hbase.util.Bytes
-import org.apache.hadoop.hbase.{HBaseConfiguration, HColumnDescriptor, HTableDescriptor, TableName}
-
+import org.apache.hadoop.hbase.{TableName, HColumnDescriptor, HBaseConfiguration, HTableDescriptor}
+import org.apache.hadoop.security.UserGroupInformation
 import scala.jdk.CollectionConverters._
 
 object HBase extends LazyLogging {
@@ -44,6 +44,15 @@ object HBase extends LazyLogging {
       c.set("hadoop.security.authentication", "kerberos")
       c.set("hbase.regionserver.kerberos.principal", kerberosConfig.regionServerPrincipal)
       c.set("hbase.master.kerberos.principal", kerberosConfig.masterPrincipal)
+
+      UserGroupInformation.setConfiguration(c)
+
+      logger.info(s"Performing Kerberos login with principal ${kerberosConfig.principal} from keytab ${kerberosConfig.keyTab}")
+
+      UserGroupInformation.loginUserFromKeytab(
+        kerberosConfig.principal,
+        kerberosConfig.keyTab
+      )
     }
     c
   }

--- a/src/main/scala/com/odsklm/salsabeach/HBase.scala
+++ b/src/main/scala/com/odsklm/salsabeach/HBase.scala
@@ -46,13 +46,6 @@ object HBase extends LazyLogging {
       c.set("hbase.master.kerberos.principal", kerberosConfig.masterPrincipal)
 
       UserGroupInformation.setConfiguration(c)
-
-      logger.info(s"Performing Kerberos login with principal ${kerberosConfig.principal} from keytab ${kerberosConfig.keyTab}")
-
-      UserGroupInformation.loginUserFromKeytab(
-        kerberosConfig.principal,
-        kerberosConfig.keyTab
-      )
     }
     c
   }
@@ -98,6 +91,16 @@ object HBase extends LazyLogging {
       kerberosConfig: Option[KerberosConfig]
     ): Connection = {
     val hBaseConf = createHBaseConfig(zkServers, port, znodeParent, kerberosConfig)
+
+    kerberosConfig.foreach { conf =>
+      logger.info(s"Performing Kerberos login with principal ${conf.principal} from keytab ${conf.keyTab}")
+
+      UserGroupInformation.loginUserFromKeytab(
+        conf.principal,
+        conf.keyTab
+      )
+    }
+
     ConnectionFactory.createConnection(hBaseConf)
   }
 


### PR DESCRIPTION
We were missing a few steps in the kerberos support of our lib. This change logs in the user upon creating the HBase configuration which is needed 'to get the ball rolling'. After this tickets will be refreshed automatically.

One thing @DandyDev : whats the release process like for this library? Can I do this or do you need to release new versions?